### PR TITLE
Initialize color variables and refine subtitle logic

### DIFF
--- a/page-templates/mentions.php
+++ b/page-templates/mentions.php
@@ -1,6 +1,7 @@
 <?php
 /* Template name: Mentions */
 get_header();
+$colorPick = "#69a7c2";
 ?>
 
 <?php

--- a/single.php
+++ b/single.php
@@ -28,6 +28,9 @@ if ($is_preview) {
     //print_r($parent_slug);
 }
 
+$colorPick = '';
+$issue_permalink = '';
+
 $issue_args = array("post_type" => "issue", "name" => $issue_slug, "posts_per_page" => -1);
 $issue_loop = new wp_query($issue_args);
 
@@ -195,16 +198,17 @@ if ($type_of_titles == "Style 2") {
                     <b>
                   <?php
                     $home_pageID = 109;
-                     $currenatPostID = get_the_id();
-                     $featuredPosts = get_post_meta($home_pageID, "select_featured_posts", true);
-
-                     if ($subsitle != "") {
-                         if (in_array($currenatPostID, $featuredPosts)) {
-                             $spanText =  "<span style='color: ".$colorPick."'> | </span>".$subsitle;
-                         } else {
-                             $spanText =  "<span> | </span>".$subsitle;
-                         }
-                     } ?>
+                    $currenatPostID = get_the_id();
+                    $featuredPosts = get_post_meta($home_pageID, "select_featured_posts", true);
+                    $spanText = '';
+                    
+                    if ($subsitle != "") {
+                        if (in_array($currenatPostID, $featuredPosts)) {
+                            $spanText =  "<span style='color: ".$colorPick."'> | </span>".$subsitle;
+                        } else {
+                            $spanText =  "<span> | </span>".$subsitle;
+                        }
+                    } ?>
                     <?php
                     wp_reset_postdata();
                     wp_reset_query();


### PR DESCRIPTION
Add explicit initialization for color and permalink variables and refine subtitle span handling. page-templates/mentions.php now sets $colorPick = "#69a7c2". single.php initializes $colorPick and $issue_permalink to avoid undefined variable notices, and the subtitle logic was adjusted to initialize $spanText and compute featured-post checks in a clearer order so the colored separator is applied correctly for featured posts.