### PR TITLE
Initialize $loopNum_test to prevent undefined variable notices

### DIFF
--- a/page-templates/issues.php
+++ b/page-templates/issues.php
@@ -68,6 +68,8 @@ if (is_array($sectionLoop)) /* Check Array */
 
         <?php
         $loopNum = 0;
+        $loopNum_test = 0;
+        
         if (is_array($add_article)) /*Check Array*/
         {
             foreach ($add_article as $articleValue) {


### PR DESCRIPTION
Add initialization for $loopNum_test (set to 0) alongside the existing $loopNum in page-templates/issues.php. This prevents undefined variable notices and provides a separate counter for the subsequent article loop.