### PR TITLE
Refine search results display, matching, and ordering

### DIFF
--- a/assets/css/custom-updated.css
+++ b/assets/css/custom-updated.css
@@ -4221,3 +4221,9 @@ form .wpfs-btn-link:visited {
     font-size: 24px;
     font-weight: 600;
 }
+
+/* The black rule under the contributors box replaces the grey separator
+   above the first result; keep the grey line when the box isn't shown. */
+.search-author-matches + .search-term-list .term-list:first-child {
+    border-top: 0;
+}

--- a/functions.php
+++ b/functions.php
@@ -1011,7 +1011,7 @@ function drift_extend_search_matches($search, $query)
             INNER JOIN {$wpdb->term_taxonomy} drift_tt ON drift_tr.term_taxonomy_id = drift_tt.term_taxonomy_id
             INNER JOIN {$wpdb->terms} drift_t ON drift_tt.term_id = drift_t.term_id
             WHERE drift_tr.object_id = {$wpdb->posts}.ID
-              AND drift_tt.taxonomy IN ('authors', 'post_tag', 'category')
+              AND drift_tt.taxonomy IN ('post_tag', 'category')
               AND drift_t.name LIKE %s
         )",
         $like
@@ -1028,19 +1028,7 @@ function drift_extend_search_matches($search, $query)
         $like
     );
 
-    $translator_match = $wpdb->prepare(
-        "EXISTS (
-            SELECT 1
-            FROM {$wpdb->postmeta} drift_tlm
-            INNER JOIN {$wpdb->terms} drift_tl ON drift_tl.term_id = CAST(drift_tlm.meta_value AS UNSIGNED)
-            WHERE drift_tlm.post_id = {$wpdb->posts}.ID
-              AND drift_tlm.meta_key = '_translator_term_id'
-              AND drift_tl.name LIKE %s
-        )",
-        $like
-    );
-
-    $extra_match = $term_match . ' OR ' . $subtitle_match . ' OR ' . $translator_match;
+    $extra_match = drift_search_byline_match_sql($search_string) . ' OR ' . $term_match . ' OR ' . $subtitle_match;
 
     // Core builds this clause as " AND (<keyword conditions>) AND (post_password = '')".
     // Inject the extra matches as ORs inside the first group so the password
@@ -1056,6 +1044,63 @@ function drift_extend_search_matches($search, $query)
     );
 
     return ($count === 1 && $extended !== null) ? $extended : $search;
+}
+
+// SQL condition matching posts the searched person is credited on, either as
+// an 'authors' term or as a translator. Used both to widen the search and to
+// rank those posts above ones that merely mention the name in the body.
+function drift_search_byline_match_sql($search_string)
+{
+    global $wpdb;
+
+    $like = '%' . $wpdb->esc_like($search_string) . '%';
+
+    $author_match = $wpdb->prepare(
+        "EXISTS (
+            SELECT 1
+            FROM {$wpdb->term_relationships} drift_atr
+            INNER JOIN {$wpdb->term_taxonomy} drift_att ON drift_atr.term_taxonomy_id = drift_att.term_taxonomy_id
+            INNER JOIN {$wpdb->terms} drift_at ON drift_att.term_id = drift_at.term_id
+            WHERE drift_atr.object_id = {$wpdb->posts}.ID
+              AND drift_att.taxonomy = 'authors'
+              AND drift_at.name LIKE %s
+        )",
+        $like
+    );
+
+    $translator_match = $wpdb->prepare(
+        "EXISTS (
+            SELECT 1
+            FROM {$wpdb->postmeta} drift_tlm
+            INNER JOIN {$wpdb->terms} drift_tl ON drift_tl.term_id = CAST(drift_tlm.meta_value AS UNSIGNED)
+            WHERE drift_tlm.post_id = {$wpdb->posts}.ID
+              AND drift_tlm.meta_key = '_translator_term_id'
+              AND drift_tl.name LIKE %s
+        )",
+        $like
+    );
+
+    return '(' . $author_match . ' OR ' . $translator_match . ')';
+}
+
+// Rank pieces written (or translated) by a matching contributor above posts
+// that only mention the search string in their text.
+add_filter('posts_orderby', 'drift_search_authored_first_orderby', 10, 2);
+
+function drift_search_authored_first_orderby($orderby, $query)
+{
+    if (is_admin() || !$query->is_main_query() || !$query->is_search()) {
+        return $orderby;
+    }
+
+    $search_string = trim((string) $query->get('s'));
+    if ($search_string === '') {
+        return $orderby;
+    }
+
+    $authored_first = '(CASE WHEN ' . drift_search_byline_match_sql($search_string) . ' THEN 0 ELSE 1 END) ASC';
+
+    return $orderby ? $authored_first . ', ' . $orderby : $authored_first;
 }
 
 // Change # of posts per page for search queries

--- a/functions.php
+++ b/functions.php
@@ -1046,6 +1046,14 @@ function drift_extend_search_matches($search, $query)
     return ($count === 1 && $extended !== null) ? $extended : $search;
 }
 
+// Escape characters that carry special meaning in a MySQL REGEXP pattern so a
+// search string is matched literally. Backslashes here survive $wpdb->prepare:
+// it doubles them in the SQL literal and MySQL collapses them back on parse.
+function drift_search_regexp_quote($string)
+{
+    return preg_replace('/[.\\\\+*?()\[\]{}^$|]/', '\\\\$0', $string);
+}
+
 // SQL condition matching posts the searched person is credited on, either as
 // an 'authors' term or as a translator. Used both to widen the search and to
 // rank those posts above ones that merely mention the name in the body.
@@ -1053,7 +1061,13 @@ function drift_search_byline_match_sql($search_string)
 {
     global $wpdb;
 
-    $like = '%' . $wpdb->esc_like($search_string) . '%';
+    // Match the credited name with the same word-boundary semantics as the
+    // contributor box in search.php, so a query like "test" boosts a name
+    // such as "Test ..." but not "Latest ...". REGEXP keeps the SQL filter
+    // in step with the PHP-side check (MySQL 8 supports \b in REGEXP). Only
+    // anchor the boundary when the query itself starts with a word character.
+    $boundary = preg_match('/^\w/u', $search_string) ? '\\b' : '';
+    $regex = $boundary . drift_search_regexp_quote($search_string);
 
     $author_match = $wpdb->prepare(
         "EXISTS (
@@ -1063,9 +1077,9 @@ function drift_search_byline_match_sql($search_string)
             INNER JOIN {$wpdb->terms} drift_at ON drift_att.term_id = drift_at.term_id
             WHERE drift_atr.object_id = {$wpdb->posts}.ID
               AND drift_att.taxonomy = 'authors'
-              AND drift_at.name LIKE %s
+              AND drift_at.name REGEXP %s
         )",
-        $like
+        $regex
     );
 
     $translator_match = $wpdb->prepare(
@@ -1075,9 +1089,9 @@ function drift_search_byline_match_sql($search_string)
             INNER JOIN {$wpdb->terms} drift_tl ON drift_tl.term_id = CAST(drift_tlm.meta_value AS UNSIGNED)
             WHERE drift_tlm.post_id = {$wpdb->posts}.ID
               AND drift_tlm.meta_key = '_translator_term_id'
-              AND drift_tl.name LIKE %s
+              AND drift_tl.name REGEXP %s
         )",
-        $like
+        $regex
     );
 
     return '(' . $author_match . ' OR ' . $translator_match . ')';

--- a/search.php
+++ b/search.php
@@ -23,6 +23,10 @@ $drift_matching_authors = array();
 if ($drift_search_string !== '') {
 	$drift_author_matches = array();
 
+	// The LIKE lookups match anywhere in a word ("test" matches "latest"),
+	// so require the query to start at a word boundary in the name or bio.
+	$drift_word_pattern = '/\b' . preg_quote($drift_search_string, '/') . '/iu';
+
 	foreach (array('name__like', 'description__like') as $drift_match_field) {
 		$drift_found = get_terms(array(
 			'taxonomy'        => 'authors',
@@ -36,6 +40,10 @@ if ($drift_search_string !== '') {
 		}
 
 		foreach ($drift_found as $drift_found_term) {
+			if (!preg_match($drift_word_pattern, $drift_found_term->name . ' ' . $drift_found_term->description)) {
+				continue;
+			}
+
 			$drift_author_matches[$drift_found_term->term_id] = $drift_found_term;
 		}
 	}

--- a/search.php
+++ b/search.php
@@ -25,14 +25,20 @@ if ($drift_search_string !== '') {
 
 	// The LIKE lookups match anywhere in a word ("test" matches "latest"),
 	// so require the query to start at a word boundary in the name or bio.
-	$drift_word_pattern = '/\b' . preg_quote($drift_search_string, '/') . '/iu';
+	// Only prepend \b when the query itself starts with a word character;
+	// otherwise (e.g. ".net", "@handle") the boundary would never match.
+	$drift_boundary = preg_match('/^\w/u', $drift_search_string) ? '\b' : '';
+	$drift_word_pattern = '/' . $drift_boundary . preg_quote($drift_search_string, '/') . '/iu';
 
 	foreach (array('name__like', 'description__like') as $drift_match_field) {
 		$drift_found = get_terms(array(
 			'taxonomy'        => 'authors',
 			$drift_match_field => $drift_search_string,
 			'hide_empty'      => false,
-			'number'          => 10,
+			// Fetch a wide candidate pool: the LIKE lookup also returns
+			// mid-word hits that the word-boundary filter below drops, so a
+			// small cap here could starve out genuine matches that sort later.
+			'number'          => 100,
 		));
 
 		if (is_wp_error($drift_found)) {
@@ -40,7 +46,10 @@ if ($drift_search_string !== '') {
 		}
 
 		foreach ($drift_found as $drift_found_term) {
-			if (!preg_match($drift_word_pattern, $drift_found_term->name . ' ' . $drift_found_term->description)) {
+			// Bios may contain HTML, so strip tags before matching to avoid
+			// false positives on markup (tag names, attributes, URLs).
+			$drift_bio_text = $drift_found_term->name . ' ' . wp_strip_all_tags($drift_found_term->description);
+			if (!preg_match($drift_word_pattern, $drift_bio_text)) {
 				continue;
 			}
 


### PR DESCRIPTION
- Hide the grey separator above the first result when the contributors box (with its black rule) is shown; keep it for regular searches
- Require contributor matches to start at a word boundary so short queries like 'test' no longer match mid-word bio text ('latest')
- Rank pieces written or translated by a matching contributor above posts that only mention the search string in their body