### PR TITLE
Keep search bar open on results page; tighten contributor matching

### DIFF
--- a/assets/css/custom-updated.css
+++ b/assets/css/custom-updated.css
@@ -2312,6 +2312,11 @@ section.mission_outer {
     display: none;
 }
 
+/* Keep the search bar open on search results pages. */
+.search .drift_searchForm {
+    display: block;
+}
+
 .single-issue .com_heading01 {
     margin-bottom: 20px;
 }

--- a/footer.php
+++ b/footer.php
@@ -130,6 +130,10 @@ if (true) {?>
 	});
 
 	jQuery(document).on("click", function(event){
+		// The search bar stays open on search results pages.
+		if(jQuery("body").hasClass("search")){
+			return;
+		}
 		var $trigger = jQuery(".drift_searchForm, .drift_search_link, .drift_search_link a");
 		if($trigger !== event.target && !$trigger.has(event.target).length){
 			jQuery(".drift_searchForm").slideUp();

--- a/footer.php
+++ b/footer.php
@@ -88,7 +88,14 @@ if (true) {?>
 		});
 
 		jQuery(".drift_search_link a").click(function(){
-			jQuery(".drift_searchForm").slideToggle();
+			// On search results pages the bar stays open: open-only, no toggle,
+			// since a slide-up writes an inline display:none that overrides
+			// the .search .drift_searchForm CSS rule.
+			if(jQuery("body").hasClass("search")){
+				jQuery(".drift_searchForm").slideDown();
+			} else {
+				jQuery(".drift_searchForm").slideToggle();
+			}
 			jQuery("#ajaxsearchlite1 input[type='search']").focus();
 			jQuery("#ajaxsearchlite3 input[type='search']").focus();
 			jQuery("#ajaxsearchlite4 input[type='search']").focus();
@@ -190,7 +197,12 @@ if (true) {?>
 
 		jQuery(".seach-mobile-view a").click(function(e){
 			e.preventDefault();
-			jQuery(".drift_searchForm").slideToggle();
+			// Open-only on search results pages; see the desktop handler above.
+			if(jQuery("body").hasClass("search")){
+				jQuery(".drift_searchForm").slideDown();
+			} else {
+				jQuery(".drift_searchForm").slideToggle();
+			}
 			jQuery("#search-form-1").focus();
 			jQuery("#ajaxsearchlite4 input[type='search']").focus();
 			return false;

--- a/header.php
+++ b/header.php
@@ -50,7 +50,7 @@ wp_head();
                             </div>
                             <span onclick="openMobileNav()" class="openMobMenuIcon">&#9776;</span>
                         </div>
-                        <div class="drift_searchForm" style="display: none;"><?php echo get_search_form();?></div>
+                        <div class="drift_searchForm"<?php if (!is_search()) { echo ' style="display: none;"'; } ?>><?php echo get_search_form();?></div>
                         <div id="myMobileNav" class="td-overlay-box">
                             <div class="td-overlay-content">
                                 <?php

--- a/search.php
+++ b/search.php
@@ -30,7 +30,16 @@ if ($drift_search_string !== '') {
 	$drift_boundary = preg_match('/^\w/u', $drift_search_string) ? '\b' : '';
 	$drift_word_pattern = '/' . $drift_boundary . preg_quote($drift_search_string, '/') . '/iu';
 
-	foreach (array('name__like', 'description__like') as $drift_match_field) {
+	// A single-word query must match the contributor's name: searching
+	// "test" shouldn't pull in a contributor whose bio mentions a book
+	// title containing the word. Bios only match deliberate multi-word
+	// phrases ("The Hearing Test").
+	$drift_match_fields = array('name__like');
+	if (preg_match('/\s/', $drift_search_string)) {
+		$drift_match_fields[] = 'description__like';
+	}
+
+	foreach ($drift_match_fields as $drift_match_field) {
 		$drift_found = get_terms(array(
 			'taxonomy'        => 'authors',
 			$drift_match_field => $drift_search_string,
@@ -46,10 +55,15 @@ if ($drift_search_string !== '') {
 		}
 
 		foreach ($drift_found as $drift_found_term) {
-			// Bios may contain HTML, so strip tags before matching to avoid
-			// false positives on markup (tag names, attributes, URLs).
-			$drift_bio_text = $drift_found_term->name . ' ' . wp_strip_all_tags($drift_found_term->description);
-			if (!preg_match($drift_word_pattern, $drift_bio_text)) {
+			// Check the candidate against the field it was found by, so a
+			// name lookup can't slip through on bio text. Bios may contain
+			// HTML, so strip tags before matching to avoid false positives
+			// on markup (tag names, attributes, URLs).
+			$drift_haystack = ($drift_match_field === 'name__like')
+				? $drift_found_term->name
+				: wp_strip_all_tags($drift_found_term->description);
+
+			if (!preg_match($drift_word_pattern, $drift_haystack)) {
 				continue;
 			}
 

--- a/search.php
+++ b/search.php
@@ -35,7 +35,7 @@ if ($drift_search_string !== '') {
 	// title containing the word. Bios only match deliberate multi-word
 	// phrases ("The Hearing Test").
 	$drift_match_fields = array('name__like');
-	if (preg_match('/\s/', $drift_search_string)) {
+	if (preg_match('/\s/u', $drift_search_string)) {
 		$drift_match_fields[] = 'description__like';
 	}
 
@@ -57,11 +57,11 @@ if ($drift_search_string !== '') {
 		foreach ($drift_found as $drift_found_term) {
 			// Check the candidate against the field it was found by, so a
 			// name lookup can't slip through on bio text. Bios may contain
-			// HTML, so strip tags before matching to avoid false positives
-			// on markup (tag names, attributes, URLs).
+			// HTML, so strip tags (against markup false positives) and decode
+			// entities (so "Smith &amp; Jones" matches the raw query).
 			$drift_haystack = ($drift_match_field === 'name__like')
 				? $drift_found_term->name
-				: wp_strip_all_tags($drift_found_term->description);
+				: html_entity_decode(wp_strip_all_tags($drift_found_term->description), ENT_QUOTES, 'UTF-8');
 
 			if (!preg_match($drift_word_pattern, $drift_haystack)) {
 				continue;


### PR DESCRIPTION
- The header search bar (prefilled with the query) now stays open on search results pages instead of requiring the magnifier click, and the click-outside handler no longer collapses it there
- Contributor results now require the query to match the author name; bios only match deliberate multi-word phrases, so a single word like 'test' can't pull in a contributor via a book title in their bio