### PR TITLE
Add subsection divider to About masthead

### DIFF
--- a/cfs-exports/README.md
+++ b/cfs-exports/README.md
@@ -1,0 +1,34 @@
+# CFS field exports
+
+Version-controlled exports of the [Custom Field Suite](https://wordpress.org/plugins/custom-field-suite/)
+field groups used by this theme. CFS stores its field definitions in the
+database, so these JSON files are the source of truth for that configuration
+in code review.
+
+## about-page.json
+
+Field group for the About / masthead page (template `page-templates/about-page.php`).
+
+Structure:
+
+```
+about_content_section (loop)        ← a masthead section, repeatable
+├─ heading_line                     ← section heading
+├─ about_subtitle                   ← section subtitle
+└─ submit_content (loop)            ← entries, repeatable
+   ├─ subsection_heading            ← optional: see below
+   ├─ about_title                   ← entry title (e.g. role)
+   └─ about_text                    ← entry text (e.g. name)
+```
+
+`subsection_heading` is optional. When an entry has it filled in, the template
+renders a dividing line and the label above that entry, demarking a new
+subsection (for example, splitting **Editorial** from **Business** within a
+single masthead section). Leave it blank on entries that continue the current
+subsection.
+
+### Importing
+
+In WordPress admin: **Field Groups → Tools → Import**, then upload this file
+(or paste its contents). This adds the `subsection_heading` field without
+affecting existing entries.

--- a/cfs-exports/README.md
+++ b/cfs-exports/README.md
@@ -27,8 +27,26 @@ subsection (for example, splitting **Editorial** from **Business** within a
 single masthead section). Leave it blank on entries that continue the current
 subsection.
 
-### Importing
+### Adding the `subsection_heading` field
 
-In WordPress admin: **Field Groups → Tools → Import**, then upload this file
-(or paste its contents). This adds the `subsection_heading` field without
-affecting existing entries.
+The About field group already exists on any site running this template, and
+CFS's **Tools → Import** does *not* merge into an existing group — it skips
+groups whose slug (`post_name`, here `about`) is already present. So importing
+this file on a live/staging site will **not** add the new field. Use the manual
+path below for existing sites; entered data is unaffected either way.
+
+**Existing site (manual — recommended):**
+
+1. WordPress admin → **Field Groups** → edit **About**.
+2. Inside the **Content** (`submit_content`) loop, add a new **Text** field:
+   - **Name:** `subsection_heading` (must match exactly)
+   - **Label:** `Subsection heading (e.g. Editorial / Business)`
+   - Drag it above the **Title** (`about_title`) field.
+3. **Save**. The field config in `about-page.json` is the reference for these
+   values.
+
+**Fresh site (no About group yet):** **Tools → Import** this file to create the
+whole group, including `subsection_heading`.
+
+> Avoid deleting the existing group to re-import — that can drop other manual
+> edits to the group. Add the single field manually instead.

--- a/cfs-exports/about-page.json
+++ b/cfs-exports/about-page.json
@@ -1,0 +1,121 @@
+[
+    {
+        "post_title": "About",
+        "post_name": "about",
+        "cfs_fields": [
+            {
+                "id": "25",
+                "name": "about_content_section",
+                "label": "Content section",
+                "type": "loop",
+                "notes": "",
+                "parent_id": 0,
+                "weight": 0,
+                "options": {
+                    "row_display": "0",
+                    "row_label": "Loop Row",
+                    "button_label": "Add Row",
+                    "limit_min": "",
+                    "limit_max": ""
+                }
+            },
+            {
+                "id": "21",
+                "name": "heading_line",
+                "label": "Heading",
+                "type": "text",
+                "notes": "",
+                "parent_id": 25,
+                "weight": 1,
+                "options": {
+                    "default_value": "",
+                    "required": "0"
+                }
+            },
+            {
+                "id": "26",
+                "name": "about_subtitle",
+                "label": "Subtitle",
+                "type": "text",
+                "notes": "",
+                "parent_id": 25,
+                "weight": 2,
+                "options": {
+                    "default_value": "",
+                    "required": "0"
+                }
+            },
+            {
+                "id": "22",
+                "name": "submit_content",
+                "label": "Content",
+                "type": "loop",
+                "notes": "",
+                "parent_id": 25,
+                "weight": 3,
+                "options": {
+                    "row_display": "0",
+                    "row_label": "Loop Row",
+                    "button_label": "Add Row",
+                    "limit_min": "",
+                    "limit_max": ""
+                }
+            },
+            {
+                "id": "27",
+                "name": "subsection_heading",
+                "label": "Subsection heading (e.g. Editorial / Business)",
+                "type": "text",
+                "notes": "Optional. When set, a dividing line and this label are shown above the entry, demarking a new subsection within the masthead. Leave blank for entries that continue the current subsection.",
+                "parent_id": 22,
+                "weight": 3,
+                "options": {
+                    "default_value": "",
+                    "required": "0"
+                }
+            },
+            {
+                "id": "23",
+                "name": "about_title",
+                "label": "Title",
+                "type": "text",
+                "notes": "",
+                "parent_id": 22,
+                "weight": 4,
+                "options": {
+                    "default_value": "",
+                    "required": "0"
+                }
+            },
+            {
+                "id": "24",
+                "name": "about_text",
+                "label": "Text",
+                "type": "textarea",
+                "notes": "",
+                "parent_id": 22,
+                "weight": 5,
+                "options": {
+                    "default_value": "",
+                    "formatting": "auto_br",
+                    "required": "0"
+                }
+            }
+        ],
+        "cfs_rules": {
+            "post_types": {
+                "operator": "==",
+                "values": ["page"]
+            },
+            "page_templates": {
+                "operator": "==",
+                "values": ["page-templates\/about-page.php"]
+            }
+        },
+        "cfs_extras": {
+            "order": "0",
+            "context": "normal",
+            "hide_editor": "0"
+        }
+    }
+]

--- a/page-templates/about-page.php
+++ b/page-templates/about-page.php
@@ -40,6 +40,20 @@ else
 		.about_outer:last-child {
 			margin-bottom: 0;
 		}
+		/* Dividing line + label that demarks a subsection (e.g. Editorial / Business)
+		   within a masthead content section. Rendered only when an entry has a
+		   subsection heading set, so existing entries are unaffected. */
+		.about_subsection {
+			border-top: 1px solid rgba(0,0,0,0.3);
+			margin: 50px 0 35px;
+			padding-top: 22px;
+		}
+		.about_subsection h5 {
+			font-family: proxy-nova;
+			font-size: 23px;
+			line-height: 1;
+			margin: 0;
+		}
 		.about_o {
 			flex-wrap: wrap;
 		}
@@ -174,12 +188,21 @@ else
 				<?php  }  ?>
 
 
-				<?php 
+				<?php
 					foreach($submit_content as $content_value)
 					{
 						$about_title = $content_value["about_title"];
 						$about_text = $content_value["about_text"];
+						$subsection_heading = isset($content_value["subsection_heading"]) ? $content_value["subsection_heading"] : "";
+
+						if($subsection_heading != "")
+						{
 				?>
+					<div class="about_subsection">
+						<h5><?php echo $subsection_heading; ?></h5>
+					</div>
+				<?php } ?>
+
 					<div class="about_o d-flex">
 
 						<div class="about_l">

--- a/page-templates/about-page.php
+++ b/page-templates/about-page.php
@@ -199,7 +199,7 @@ else
 						{
 				?>
 					<div class="about_subsection">
-						<h5><?php echo $subsection_heading; ?></h5>
+						<h5><?php echo esc_html( $subsection_heading ); ?></h5>
 					</div>
 				<?php } ?>
 


### PR DESCRIPTION
Add an optional subsection_heading field to the about_content_section > submit_content loop so editors can demark groups (e.g. Editorial vs Business) within a single masthead section. When set, the template renders a dividing line and the label above that entry; entries without it are unaffected.

- about-page.php: render .about_subsection divider/label when present
- cfs-exports/about-page.json: version-controlled CFS field group with the new subsection_heading field, importable in WP admin
- cfs-exports/README.md: document the field group and import steps
