### PR TITLE
Center masthead subsection divider at 75% width

### DIFF
--- a/page-templates/about-page.php
+++ b/page-templates/about-page.php
@@ -45,7 +45,8 @@ else
 		   subsection heading set, so existing entries are unaffected. */
 		.about_subsection {
 			border-top: 1px solid rgba(0,0,0,0.3);
-			margin: 50px 0 35px;
+			width: 75%;
+			margin: 50px auto 35px;
 			padding-top: 22px;
 		}
 		.about_subsection h5 {


### PR DESCRIPTION
Constrain the subsection dividing line to 75% width with auto left/right margins so it sits centered rather than spanning the full content column.